### PR TITLE
[FEATURE] Add compute_layout overload that fills counts and sketches.

### DIFF
--- a/include/hibf/detail/layout/compute_layout.hpp
+++ b/include/hibf/detail/layout/compute_layout.hpp
@@ -2,9 +2,18 @@
 
 #include <hibf/config.hpp>               // for config
 #include <hibf/detail/layout/layout.hpp> // for layout
+#include <vector>
+
+#include <hibf/config.hpp>
+#include <hibf/detail/layout/layout.hpp>
+#include <hibf/detail/sketch/hyperloglog.hpp>
 
 namespace hibf::layout
 {
+
+layout compute_layout(config const & hibf_config,
+                      std::vector<size_t> & kmer_counts,
+                      std::vector<sketch::hyperloglog> & sketches);
 
 layout compute_layout(config const & hibf_config);
 

--- a/include/hibf/detail/layout/compute_layout.hpp
+++ b/include/hibf/detail/layout/compute_layout.hpp
@@ -1,16 +1,21 @@
 #pragma once
 
-#include <hibf/config.hpp>               // for config
-#include <hibf/detail/layout/layout.hpp> // for layout
-#include <vector>
+#include <cstddef> // for size_t
+#include <vector>  // for vector
 
-#include <hibf/config.hpp>
-#include <hibf/detail/layout/layout.hpp>
-#include <hibf/detail/sketch/hyperloglog.hpp>
+#include <hibf/config.hpp>                    // for config
+#include <hibf/detail/layout/layout.hpp>      // for layout
+#include <hibf/detail/sketch/hyperloglog.hpp> // for hyperloglog
 
 namespace hibf::layout
 {
 
+/*!\brief Computes the layout and stores the kmer_counts and sketches in the respective vectors for further use.
+ * \param hibf_config The configuration to compute the layout with.
+ * \param[in,out] kmer_counts The vector that will store the kmer counts (estimations).
+ * \param[in,out] sketches The vector that will store the sketches.
+ * \returns layout
+ */
 layout compute_layout(config const & hibf_config,
                       std::vector<size_t> & kmer_counts,
                       std::vector<sketch::hyperloglog> & sketches);

--- a/src/detail/layout/compute_layout.cpp
+++ b/src/detail/layout/compute_layout.cpp
@@ -38,14 +38,8 @@ layout compute_layout(config const & hibf_config)
     std::stringstream output_buffer;
     std::stringstream header_buffer;
 
-    std::vector<std::string> filenames{};
     std::vector<size_t> kmer_counts{};
     std::vector<sketch::hyperloglog> sketches{};
-
-    // dummy init filenames
-    filenames.resize(hibf_config.number_of_user_bins);
-    for (size_t i = 0; i < hibf_config.number_of_user_bins; ++i)
-        filenames[i] = "UB_" + std::to_string(i);
 
     // compute sketches
     sketches.resize(hibf_config.number_of_user_bins);

--- a/src/detail/layout/compute_layout.cpp
+++ b/src/detail/layout/compute_layout.cpp
@@ -17,14 +17,7 @@
 
 namespace hibf::layout
 {
-/**
- * @brief Compute the layout and stores the kmer_counts and sketches in the respective vectors for further use.
- *
- * @param hibf_config The configuration to compute the layout.
- * @param kmer_counts The vector that will store the kmer count( estimation)s after layout computation.
- * @param sketches The vector that will store the sketches after layout computation.
- * @return layout
- */
+
 layout compute_layout(config const & hibf_config,
                       std::vector<size_t> & kmer_counts,
                       std::vector<sketch::hyperloglog> & sketches)

--- a/src/detail/layout/compute_layout.cpp
+++ b/src/detail/layout/compute_layout.cpp
@@ -17,8 +17,17 @@
 
 namespace hibf::layout
 {
-
-layout compute_layout(config const & hibf_config)
+/**
+ * @brief Compute the layout and stores the kmer_counts and sketches in the respective vectors for further use.
+ *
+ * @param hibf_config The configuration to compute the layout.
+ * @param kmer_counts The vector that will store the kmer count( estimation)s after layout computation.
+ * @param sketches The vector that will store the sketches after layout computation.
+ * @return layout
+ */
+layout compute_layout(config const & hibf_config,
+                      std::vector<size_t> & kmer_counts,
+                      std::vector<sketch::hyperloglog> & sketches)
 {
     layout resulting_layout{};
 
@@ -37,9 +46,6 @@ layout compute_layout(config const & hibf_config)
     // hibf::execute currently writes the filled buffers to the output file.
     std::stringstream output_buffer;
     std::stringstream header_buffer;
-
-    std::vector<size_t> kmer_counts{};
-    std::vector<sketch::hyperloglog> sketches{};
 
     // compute sketches
     sketches.resize(hibf_config.number_of_user_bins);
@@ -72,6 +78,14 @@ layout compute_layout(config const & hibf_config)
     store.hibf_layout->top_level_max_bin_id = max_hibf_id;
 
     return *store.hibf_layout; // return layout as string for now, containing the file
+}
+
+layout compute_layout(config const & hibf_config)
+{
+    std::vector<size_t> kmer_counts{};
+    std::vector<sketch::hyperloglog> sketches{};
+
+    return compute_layout(hibf_config, kmer_counts, sketches);
 }
 
 } // namespace hibf::layout


### PR DESCRIPTION
In chopper I need the sketches and counts when I want to compute statistics on the layout. 
To avoid computing the sketches again which potentially differ in the way I compute them when HIBF lib versions change, I let `compute_layout` have two output arguments that are filled.

Having access to the counts and sketches might be interesting in other scenarios too. 