### PR TITLE
[MISC] Use reference_wrapper

### DIFF
--- a/include/hibf/detail/data_store.hpp
+++ b/include/hibf/detail/data_store.hpp
@@ -41,13 +41,13 @@ struct data_store
     double false_positive_rate{};
 
     //!\brief The layout that is built by layout::hierarchical_binning.
-    layout::layout * hibf_layout; // Will be modified by {simple,hierarchical}_binning.
+    std::reference_wrapper<layout::layout> hibf_layout; // Will be modified by {simple,hierarchical}_binning.
 
     //!\brief The kmer counts associated with the above files used to layout user bin into technical bins.
-    std::vector<size_t> const * kmer_counts{}; // Pointed to data should not be modified.
+    std::reference_wrapper<std::vector<size_t> const> kmer_counts; // Pointed to data should not be modified.
 
     //!\brief The hyperloglog sketches of all input files to estimate their size and similarities.
-    std::vector<sketch::hyperloglog> const * sketches{}; // Pointed to data should not be modified.
+    std::reference_wrapper<std::vector<sketch::hyperloglog> const> sketches; // Pointed to data should not be modified.
     //!\}
 
     /*!\name Local Storage one IBF in the HIBF.
@@ -61,7 +61,7 @@ struct data_store
     std::vector<size_t> positions = [this]()
     {
         std::vector<size_t> ps;
-        ps.resize(this->kmer_counts->size());
+        ps.resize(this->kmer_counts.get().size());
         std::iota(ps.begin(), ps.end(), 0);
         return ps;
     }();

--- a/src/detail/layout/compute_layout.cpp
+++ b/src/detail/layout/compute_layout.cpp
@@ -64,14 +64,14 @@ layout compute_layout(config const & hibf_config,
     sketch::estimate_kmer_counts(sketches, kmer_counts);
 
     data_store store{.false_positive_rate = chopper_config.false_positive_rate,
-                     .hibf_layout = &resulting_layout,
-                     .kmer_counts = std::addressof(kmer_counts),
-                     .sketches = std::addressof(sketches)};
+                     .hibf_layout = std::ref(resulting_layout),
+                     .kmer_counts = std::cref(kmer_counts),
+                     .sketches = std::cref(sketches)};
 
     size_t const max_hibf_id = hibf::execute(chopper_config, store);
-    store.hibf_layout->top_level_max_bin_id = max_hibf_id;
+    store.hibf_layout.get().top_level_max_bin_id = max_hibf_id;
 
-    return *store.hibf_layout; // return layout as string for now, containing the file
+    return store.hibf_layout.get(); // return layout as string for now, containing the file
 }
 
 layout compute_layout(config const & hibf_config)

--- a/src/detail/layout/execute.cpp
+++ b/src/detail/layout/execute.cpp
@@ -23,7 +23,7 @@ size_t execute(hibf::configuration & config, hibf::data_store & data)
     if (config.tmax == 0) // no tmax was set by the user on the command line
     {
         // Set default as sqrt(#samples). Experiments showed that this is a reasonable default.
-        if (size_t number_samples = data.kmer_counts->size();
+        if (size_t number_samples = data.kmer_counts.get().size();
             number_samples >= 1ULL << 32) // sqrt is bigger than uint16_t
             throw std::invalid_argument{"Too many samples. Please set a tmax (see help via `-hh`)."}; // GCOVR_EXCL_LINE
         else

--- a/src/detail/layout/simple_binning.cpp
+++ b/src/detail/layout/simple_binning.cpp
@@ -79,9 +79,9 @@ size_t simple_binning::execute()
         size_t const kmer_count_per_bin = (kmer_count + number_of_bins - 1) / number_of_bins; // round up
 
         hibf_layout.user_bins.emplace_back(data->positions[trace_j],
-                                                  data->previous.bin_indices,
-                                                  number_of_bins,
-                                                  bin_id);
+                                           data->previous.bin_indices,
+                                           number_of_bins,
+                                           bin_id);
 
         if (kmer_count_per_bin > max_size)
         {

--- a/src/detail/layout/simple_binning.cpp
+++ b/src/detail/layout/simple_binning.cpp
@@ -14,6 +14,8 @@ namespace hibf::layout
 size_t simple_binning::execute()
 {
     assert(data != nullptr);
+    auto const & kmer_counts = data->kmer_counts.get();
+    auto & hibf_layout = data->hibf_layout.get();
 
     std::vector<std::vector<size_t>> matrix(num_technical_bins); // rows
     for (auto & v : matrix)
@@ -26,7 +28,7 @@ size_t simple_binning::execute()
     size_t const extra_bins = num_technical_bins - num_user_bins + 1;
 
     // initialize first column (first row is initialized with inf)
-    double const ub_cardinality = static_cast<double>((*data->kmer_counts)[data->positions[0]]);
+    double const ub_cardinality = static_cast<double>(kmer_counts[data->positions[0]]);
     for (size_t i = 0; i < extra_bins; ++i)
     {
         size_t const corrected_ub_cardinality = static_cast<size_t>(ub_cardinality * data->fpr_correction[i + 1]);
@@ -36,7 +38,7 @@ size_t simple_binning::execute()
     // we must iterate column wise
     for (size_t j = 1; j < num_user_bins; ++j)
     {
-        double const ub_cardinality = static_cast<double>((*data->kmer_counts)[data->positions[j]]);
+        double const ub_cardinality = static_cast<double>(kmer_counts[data->positions[j]]);
 
         for (size_t i = j; i < j + extra_bins; ++i)
         {
@@ -72,11 +74,11 @@ size_t simple_binning::execute()
     while (trace_j > 0)
     {
         size_t next_i = trace[trace_i][trace_j];
-        size_t const kmer_count = (*data->kmer_counts)[data->positions[trace_j]];
+        size_t const kmer_count = kmer_counts[data->positions[trace_j]];
         size_t const number_of_bins = (trace_i - next_i);
         size_t const kmer_count_per_bin = (kmer_count + number_of_bins - 1) / number_of_bins; // round up
 
-        data->hibf_layout->user_bins.emplace_back(data->positions[trace_j],
+        hibf_layout.user_bins.emplace_back(data->positions[trace_j],
                                                   data->previous.bin_indices,
                                                   number_of_bins,
                                                   bin_id);
@@ -93,10 +95,10 @@ size_t simple_binning::execute()
         --trace_j;
     }
     ++trace_i; // because we want the length not the index. Now trace_i == number_of_bins
-    size_t const kmer_count = (*data->kmer_counts)[data->positions[0]];
+    size_t const kmer_count = kmer_counts[data->positions[0]];
     size_t const kmer_count_per_bin = (kmer_count + trace_i - 1) / trace_i;
 
-    data->hibf_layout->user_bins.emplace_back(data->positions[0], data->previous.bin_indices, trace_i, bin_id);
+    hibf_layout.user_bins.emplace_back(data->positions[0], data->previous.bin_indices, trace_i, bin_id);
 
     if (kmer_count_per_bin > max_size)
         max_id = bin_id;

--- a/test/unit/hibf/detail/layout/hierarchical_binning_test.cpp
+++ b/test/unit/hibf/detail/layout/hierarchical_binning_test.cpp
@@ -18,8 +18,11 @@ TEST(hierarchical_binning_test, small_example)
 
     hibf::layout::layout hibf_layout{};
     std::vector<size_t> kmer_counts{500, 1000, 500, 500, 500, 500, 500, 500};
+    std::vector<hibf::sketch::hyperloglog> sketches{};
 
-    hibf::data_store data{.hibf_layout = &hibf_layout, .kmer_counts = &kmer_counts};
+    hibf::data_store data{.hibf_layout = std::ref(hibf_layout),
+                          .kmer_counts = std::cref(kmer_counts),
+                          .sketches = std::cref(sketches)};
 
     data.fpr_correction = hibf::layout::compute_fpr_correction({.fpr = 0.05, .hash_count = 2, .t_max = config.tmax});
     hibf::layout::hierarchical_binning algo{data, config};
@@ -48,7 +51,10 @@ TEST(hierarchical_binning_test, another_example)
 
     hibf::layout::layout hibf_layout{};
     std::vector<size_t> kmer_counts{50, 1000, 1000, 50, 5, 10, 10, 5};
-    hibf::data_store data{.hibf_layout = &hibf_layout, .kmer_counts = &kmer_counts};
+    std::vector<hibf::sketch::hyperloglog> sketches{};
+    hibf::data_store data{.hibf_layout = std::ref(hibf_layout),
+                          .kmer_counts = std::cref(kmer_counts),
+                          .sketches = std::cref(sketches)};
 
     data.fpr_correction = hibf::layout::compute_fpr_correction({.fpr = 0.05, .hash_count = 2, .t_max = config.tmax});
 
@@ -78,7 +84,10 @@ TEST(hierarchical_binning_test, high_level_max_bin_id_is_0)
 
     hibf::layout::layout hibf_layout{};
     std::vector<size_t> kmer_counts{500, 500, 500, 500};
-    hibf::data_store data{.hibf_layout = &hibf_layout, .kmer_counts = &kmer_counts};
+    std::vector<hibf::sketch::hyperloglog> sketches{};
+    hibf::data_store data{.hibf_layout = std::ref(hibf_layout),
+                          .kmer_counts = std::cref(kmer_counts),
+                          .sketches = std::cref(sketches)};
 
     data.fpr_correction = hibf::layout::compute_fpr_correction({.fpr = 0.05, .hash_count = 2, .t_max = config.tmax});
 
@@ -102,7 +111,10 @@ TEST(hierarchical_binning_test, knuts_example)
 
     hibf::layout::layout hibf_layout{};
     std::vector<size_t> kmer_counts{60, 600, 1000, 800, 800};
-    hibf::data_store data{.hibf_layout = &hibf_layout, .kmer_counts = &kmer_counts};
+    std::vector<hibf::sketch::hyperloglog> sketches{};
+    hibf::data_store data{.hibf_layout = std::ref(hibf_layout),
+                          .kmer_counts = std::cref(kmer_counts),
+                          .sketches = std::cref(sketches)};
 
     data.fpr_correction = hibf::layout::compute_fpr_correction({.fpr = 0.05, .hash_count = 2, .t_max = config.tmax});
 
@@ -129,7 +141,10 @@ TEST(hierarchical_binning_test, four_level_hibf)
 
     hibf::layout::layout hibf_layout{};
     std::vector<size_t> kmer_counts{11090, 5080, 3040, 1020, 510, 500};
-    hibf::data_store data{.hibf_layout = &hibf_layout, .kmer_counts = &kmer_counts};
+    std::vector<hibf::sketch::hyperloglog> sketches{};
+    hibf::data_store data{.hibf_layout = std::ref(hibf_layout),
+                          .kmer_counts = std::cref(kmer_counts),
+                          .sketches = std::cref(sketches)};
 
     data.fpr_correction = hibf::layout::compute_fpr_correction({.fpr = 0.05, .hash_count = 2, .t_max = config.tmax});
 
@@ -161,7 +176,10 @@ TEST(hierarchical_binning_test, tb0_is_a_merged_bin)
 
     hibf::layout::layout hibf_layout{};
     std::vector<size_t> kmer_counts{500, 500, 500, 500};
-    hibf::data_store data{.hibf_layout = &hibf_layout, .kmer_counts = &kmer_counts};
+    std::vector<hibf::sketch::hyperloglog> sketches{};
+    hibf::data_store data{.hibf_layout = std::ref(hibf_layout),
+                          .kmer_counts = std::cref(kmer_counts),
+                          .sketches = std::cref(sketches)};
 
     data.fpr_correction = hibf::layout::compute_fpr_correction({.fpr = 0.05, .hash_count = 2, .t_max = config.tmax});
 
@@ -188,7 +206,10 @@ TEST(hierarchical_binning_test, tb0_is_a_merged_bin_and_leads_to_recursive_call)
 
     hibf::layout::layout hibf_layout{};
     std::vector<size_t> kmer_counts{500, 500, 500, 500, 500, 500, 500, 500};
-    hibf::data_store data{.hibf_layout = &hibf_layout, .kmer_counts = &kmer_counts};
+    std::vector<hibf::sketch::hyperloglog> sketches{};
+    hibf::data_store data{.hibf_layout = std::ref(hibf_layout),
+                          .kmer_counts = std::cref(kmer_counts),
+                          .sketches = std::cref(sketches)};
 
     data.fpr_correction = hibf::layout::compute_fpr_correction({.fpr = 0.05, .hash_count = 2, .t_max = config.tmax});
 


### PR DESCRIPTION
While
```cpp
    hibf::data_store data{.hibf_layout = std::ref(hibf_layout),
                          .kmer_counts = std::cref(kmer_counts),
                          .sketches = std::cref(sketches)};
```
at least indicates that the data is not owned, the `std::ref`/`std::cref` is not necessary, because the `reference_wrapper` has ctors for the underlying type.