### PR TITLE
[MISC] Remove config copy

### DIFF
--- a/include/hibf/detail/layout/hierarchical_binning.hpp
+++ b/include/hibf/detail/layout/hierarchical_binning.hpp
@@ -41,14 +41,7 @@ public:
      * Each entry in the names_ and input vector respectively is considered a user bin (both vectors must have the
      * same length).
      */
-    hierarchical_binning(data_store & data_, hibf::config const & config_) :
-        config{config_},
-        data{std::addressof(data_)},
-        num_user_bins{data->positions.size()},
-        num_technical_bins{data->previous.empty() ? config.tmax : needed_technical_bins(num_user_bins)}
-    {
-        assert(data != nullptr);
-    }
+    hierarchical_binning(data_store & data_, hibf::config const & config_);
 
     //!\brief Executes the hierarchical binning algorithm and layouts user bins into technical bins.
     size_t execute();

--- a/src/detail/layout/execute.cpp
+++ b/src/detail/layout/execute.cpp
@@ -17,34 +17,12 @@ namespace hibf
 
 size_t execute(hibf::config const & config, hibf::data_store & data)
 {
-    hibf::config config_copy{config};
-
-    if (config_copy.disable_estimate_union)
-        config_copy.disable_rearrangement = true;
-
-    if (config_copy.tmax == 0) // no tmax was set by the user on the command line
-    {
-        // Set default as sqrt(#samples). Experiments showed that this is a reasonable default.
-        if (size_t number_samples = data.kmer_counts->size();
-            number_samples >= 1ULL << 32) // sqrt is bigger than uint16_t
-            throw std::invalid_argument{"Too many samples. Please set a tmax (see help via `-hh`)."}; // GCOVR_EXCL_LINE
-        else
-            config_copy.tmax = hibf::next_multiple_of_64(static_cast<uint16_t>(std::ceil(std::sqrt(number_samples))));
-    }
-    else if (config_copy.tmax % 64 != 0)
-    {
-        config_copy.tmax = hibf::next_multiple_of_64(config_copy.tmax);
-        std::cerr << "[HIBF LAYOUT WARNING]: Your requested number of technical bins was not a multiple of 64. "
-                  << "Due to the architecture of the HIBF, it will use up space equal to the next multiple of 64 "
-                  << "anyway, so we increased your number of technical bins to " << config_copy.tmax << ".\n";
-    }
-
     data.fpr_correction =
-        layout::compute_fpr_correction({.fpr = config_copy.maximum_false_positive_rate, // prevent clang-format
-                                        .hash_count = config_copy.number_of_hash_functions,
-                                        .t_max = config_copy.tmax});
+        layout::compute_fpr_correction({.fpr = config.maximum_false_positive_rate, // prevent clang-format
+                                        .hash_count = config.number_of_hash_functions,
+                                        .t_max = config.tmax});
 
-    return hibf::layout::hierarchical_binning{data, config_copy}.execute();
+    return hibf::layout::hierarchical_binning{data, config}.execute();
 }
 
 } // namespace hibf

--- a/src/detail/layout/execute.cpp
+++ b/src/detail/layout/execute.cpp
@@ -1,27 +1,19 @@
 #include <cinttypes> // for uint16_t
-#include <cmath>     // for ceil, sqrt
 #include <cstddef>   // for size_t
 #include <iostream>  // for char_traits, operator<<, basic_ostream, cerr
 #include <stdexcept> // for invalid_argument
 #include <vector>    // for vector
 
-#include <hibf/config.hpp>                               // for config
-#include <hibf/detail/data_store.hpp>                    // for data_store
-#include <hibf/detail/layout/compute_fpr_correction.hpp> // for compute_fpr_correction
-#include <hibf/detail/layout/execute.hpp>                // for execute
-#include <hibf/detail/layout/hierarchical_binning.hpp>   // for hierarchical_binning
-#include <hibf/next_multiple_of_64.hpp>                  // for next_multiple_of_64
+#include <hibf/config.hpp>                             // for config
+#include <hibf/detail/data_store.hpp>                  // for data_store
+#include <hibf/detail/layout/execute.hpp>              // for execute
+#include <hibf/detail/layout/hierarchical_binning.hpp> // for hierarchical_binning
 
 namespace hibf
 {
 
 size_t execute(hibf::config const & config, hibf::data_store & data)
 {
-    data.fpr_correction =
-        layout::compute_fpr_correction({.fpr = config.maximum_false_positive_rate, // prevent clang-format
-                                        .hash_count = config.number_of_hash_functions,
-                                        .t_max = config.tmax});
-
     return hibf::layout::hierarchical_binning{data, config}.execute();
 }
 

--- a/src/hierarchical_interleaved_bloom_filter.cpp
+++ b/src/hierarchical_interleaved_bloom_filter.cpp
@@ -195,30 +195,8 @@ void build_index(hierarchical_interleaved_bloom_filter & hibf,
 
 hierarchical_interleaved_bloom_filter::hierarchical_interleaved_bloom_filter(config const & configuration)
 {
-    hibf::config config_copy{configuration};
-
-    if (config_copy.disable_estimate_union)
-        config_copy.disable_rearrangement = true;
-
-    if (config_copy.tmax == 0) // no tmax was set by the user on the command line
-    {
-        // Set default as sqrt(#samples). Experiments showed that this is a reasonable default.
-        if (size_t number_samples = data.kmer_counts->size();
-            number_samples >= 1ULL << 32) // sqrt is bigger than uint16_t
-            throw std::invalid_argument{"Too many samples. Please set a tmax (see help via `-hh`)."}; // GCOVR_EXCL_LINE
-        else
-            config_copy.tmax = hibf::next_multiple_of_64(static_cast<uint16_t>(std::ceil(std::sqrt(number_samples))));
-    }
-    else if (config_copy.tmax % 64 != 0)
-    {
-        config_copy.tmax = hibf::next_multiple_of_64(config_copy.tmax);
-        std::cerr << "[HIBF LAYOUT WARNING]: Your requested number of technical bins was not a multiple of 64. "
-                  << "Due to the architecture of the HIBF, it will use up space equal to the next multiple of 64 "
-                  << "anyway, so we increased your number of technical bins to " << config_copy.tmax << ".\n";
-    }
-
-    auto layout = layout::compute_layout(config_copy);
-    build_index(*this, config_copy, layout);
+    auto layout = layout::compute_layout(configuration);
+    build_index(*this, configuration, layout);
 }
 
 } // namespace hibf

--- a/src/hierarchical_interleaved_bloom_filter.cpp
+++ b/src/hierarchical_interleaved_bloom_filter.cpp
@@ -195,8 +195,30 @@ void build_index(hierarchical_interleaved_bloom_filter & hibf,
 
 hierarchical_interleaved_bloom_filter::hierarchical_interleaved_bloom_filter(config const & configuration)
 {
-    auto layout = layout::compute_layout(configuration);
-    build_index(*this, configuration, layout);
+    hibf::config config_copy{configuration};
+
+    if (config_copy.disable_estimate_union)
+        config_copy.disable_rearrangement = true;
+
+    if (config_copy.tmax == 0) // no tmax was set by the user on the command line
+    {
+        // Set default as sqrt(#samples). Experiments showed that this is a reasonable default.
+        if (size_t number_samples = data.kmer_counts->size();
+            number_samples >= 1ULL << 32) // sqrt is bigger than uint16_t
+            throw std::invalid_argument{"Too many samples. Please set a tmax (see help via `-hh`)."}; // GCOVR_EXCL_LINE
+        else
+            config_copy.tmax = hibf::next_multiple_of_64(static_cast<uint16_t>(std::ceil(std::sqrt(number_samples))));
+    }
+    else if (config_copy.tmax % 64 != 0)
+    {
+        config_copy.tmax = hibf::next_multiple_of_64(config_copy.tmax);
+        std::cerr << "[HIBF LAYOUT WARNING]: Your requested number of technical bins was not a multiple of 64. "
+                  << "Due to the architecture of the HIBF, it will use up space equal to the next multiple of 64 "
+                  << "anyway, so we increased your number of technical bins to " << config_copy.tmax << ".\n";
+    }
+
+    auto layout = layout::compute_layout(config_copy);
+    build_index(*this, config_copy, layout);
 }
 
 } // namespace hibf


### PR DESCRIPTION
Putting everything into `hierarchical_binning::hierarchical_binning` will make tests fail, because they then use `tmax=64` instead of `tmax=5`