### PR TITLE
[INFRA] Allow setting the submodule directory

### DIFF
--- a/cmake/configuration.cmake
+++ b/cmake/configuration.cmake
@@ -38,7 +38,11 @@ endmacro ()
 # Add submodules
 # ----------------------------------------------------------------------------
 
-file (GLOB submodules ${HIBF_SOURCE_DIR}/submodules/*/include ${HIBF_SOURCE_DIR}/submodules/simde/simde)
+set (HIBF_SUBMODULES_DIR
+     "${HIBF_SOURCE_DIR}"
+     CACHE STRING "Directory containing submodules.")
+file (GLOB submodules ${HIBF_SUBMODULES_DIR}/submodules/*/include ${HIBF_SUBMODULES_DIR}/submodules/simde/simde
+      ${HIBF_SUBMODULES_DIR}/simde/simde)
 foreach (submodule ${submodules})
     if (IS_DIRECTORY ${submodule})
         hibf_config_print ("  …adding submodule include: ${submodule}")


### PR DESCRIPTION
Makes it a bit easier to integrate into raptor because I can just reuse my submodules.