### PR TITLE
[FIX] Overwrite threads when construction from layout

### DIFF
--- a/include/hibf/hierarchical_interleaved_bloom_filter.hpp
+++ b/include/hibf/hierarchical_interleaved_bloom_filter.hpp
@@ -114,7 +114,8 @@ public:
      * or raptor-layout (https://github.com/seqan/raptor).
      */
     hierarchical_interleaved_bloom_filter(std::function<void(size_t const, insert_iterator &&)> input_fn,
-                                          std::istream & layout_stream);
+                                          std::istream & layout_stream,
+                                          size_t const threads = 1u);
     //!\}
 
     //!\brief The individual interleaved Bloom filters.

--- a/src/hierarchical_interleaved_bloom_filter.cpp
+++ b/src/hierarchical_interleaved_bloom_filter.cpp
@@ -193,7 +193,8 @@ hierarchical_interleaved_bloom_filter::hierarchical_interleaved_bloom_filter(con
 
 hierarchical_interleaved_bloom_filter::hierarchical_interleaved_bloom_filter(
     std::function<void(size_t const, insert_iterator &&)> input_fn,
-    std::istream & layout_stream)
+    std::istream & layout_stream,
+    size_t const threads)
 {
     // read config and layout from file
     config configuration;
@@ -202,6 +203,7 @@ hierarchical_interleaved_bloom_filter::hierarchical_interleaved_bloom_filter(
     hibf_layout.read_from(layout_stream);
 
     configuration.input_fn = input_fn; // set input as it cannot be serialized.
+    configuration.threads = threads;   // set threads as it shouldn't use what was used to compute the layout.
 
     build_index(*this, configuration, hibf_layout);
 }


### PR DESCRIPTION
For example, when the layout was built with `12` threads, the build would always use `12` threads.

Maybe there is a more elegant way, but for now this fixes my issue :)