### PR TITLE
[MISC] Expose timer after HIBF construction

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,6 +1,6 @@
 # Format all files in include folder, including std module, excluding contrib module
 # find . -iname "*.[ch]pp" -not -path "./include/hibf/contrib/*" -not -path "./submodules/*" -not -path "./build/*" | xargs clang-format-15 --style=file -i
-# Staged files: git diff --name-only HEAD | grep -E "(\.cpp|\.hpp)$" | xargs clang-format-15 --style=file -i
+# Staged files: git diff --name-only HEAD --diff-filter=ACMRT | grep -E "(\.cpp|\.hpp)$" | xargs clang-format-15 --style=file -i
 ---
 Language:        Cpp
 AccessModifierOffset: -4

--- a/include/hibf/build/build_data.hpp
+++ b/include/hibf/build/build_data.hpp
@@ -29,13 +29,10 @@ struct build_data
     std::vector<double> fpr_correction{};
 
     // Timers do not copy the stored duration upon copy construction/assignment
-    mutable timer<concurrent::yes> wall_clock_timer{};
-    mutable timer<concurrent::yes> bin_size_timer{};
     mutable timer<concurrent::yes> index_allocation_timer{};
     mutable timer<concurrent::yes> user_bin_io_timer{};
     mutable timer<concurrent::yes> merge_kmers_timer{};
     mutable timer<concurrent::yes> fill_ibf_timer{};
-    mutable timer<concurrent::yes> store_index_timer{};
 
     size_t request_ibf_idx()
     {

--- a/include/hibf/detail/timer.hpp
+++ b/include/hibf/detail/timer.hpp
@@ -104,4 +104,8 @@ private:
     rep_t ticks{};
 };
 
+// seqan::hibf::{serial,concurrent}_timer is easier to use than `seqan::hibf::timer<seqan::hibf::concurrent::{no,yes}.
+using serial_timer = timer<concurrent::no>;
+using concurrent_timer = timer<concurrent::yes>;
+
 } // namespace seqan::hibf

--- a/include/hibf/hierarchical_interleaved_bloom_filter.hpp
+++ b/include/hibf/hierarchical_interleaved_bloom_filter.hpp
@@ -19,6 +19,7 @@
 
 #include <hibf/cereal/concepts.hpp>          // for cereal_archive
 #include <hibf/config.hpp>                   // for config
+#include <hibf/detail/timer.hpp>             // for concurrent, timer
 #include <hibf/interleaved_bloom_filter.hpp> // for interleaved_bloom_filter
 #include <hibf/user_bins_type.hpp>           // for user_bins_type
 
@@ -151,6 +152,16 @@ public:
         archive(next_ibf_id);
         archive(user_bins);
     }
+
+    /*!\name Timer
+     * \brief Only contains values after the HIBF has been constructed.
+     * \{
+     */
+    timer<concurrent::yes> index_allocation_timer{};
+    timer<concurrent::yes> user_bin_io_timer{};
+    timer<concurrent::yes> merge_kmers_timer{};
+    timer<concurrent::yes> fill_ibf_timer{};
+    //!\}
     //!\endcond
 };
 

--- a/src/hierarchical_interleaved_bloom_filter.cpp
+++ b/src/hierarchical_interleaved_bloom_filter.cpp
@@ -183,6 +183,11 @@ void build_index(hierarchical_interleaved_bloom_filter & hibf,
         {.fpr = config.maximum_false_positive_rate, .hash_count = config.number_of_hash_functions, .t_max = t_max});
 
     hierarchical_build(hibf, root_node, data);
+
+    hibf.index_allocation_timer = std::move(data.index_allocation_timer);
+    hibf.user_bin_io_timer = std::move(data.user_bin_io_timer);
+    hibf.merge_kmers_timer = std::move(data.merge_kmers_timer);
+    hibf.fill_ibf_timer = std::move(data.fill_ibf_timer);
 }
 
 hierarchical_interleaved_bloom_filter::hierarchical_interleaved_bloom_filter(config const & configuration)


### PR DESCRIPTION
Removed timer:
* wall_clock_timer - unused, used in raptor to track wall clock time
* bin_size_timer - unused, used in raptor to track determining the maximum bin size when constructing an IBF in raptor
* store_index_timer - unused, used in raptor to track how long it takes to write the index to disk