### PR TITLE
[MISC] Pass mutable to hibf ctor and avoid config copy

### DIFF
--- a/include/hibf/config.hpp
+++ b/include/hibf/config.hpp
@@ -75,6 +75,23 @@ struct config
     void read_from(std::istream & stream);
     void write_to(std::ostream & stream) const;
 
+    /*!\brief Checks several variables of seqan::hibf::config and sets default values if necessary.
+     *
+     * The following checks are performed and will throw an exception if the checks fail:
+     * * seqan::hibf::config::number_of_user_bins must be greather than `0`.
+     * * If seqan::hibf::config::tmax is `0`, seqan::hibf::config::number_of_user_bins must be
+     *   smaller than `1ULL << 32`.
+     *
+     * The configuration might be modified before being passed to the HIBF construction algorithm:
+     * * If seqan::hibf::config::disable_estimate_union is `true`, seqan::hibf::config::disable_rearrangement will be
+     *   set to `true` . Without union estimation, no rearrangement can be done.
+     * * If seqan::hibf::config::tmax is `0`, the default value of `std::ceil(std::sqrt(cfg.number_of_user_bins))` will
+     *   be used.
+     * * If seqan::hibf::config::tmax is **not** `0` but also not a multiple of 64, it is increased to the next multiple
+     *   of 64. E.g., the value `60` will be increased to `64`, and `1000` to `1024`.
+     */
+    void validate_and_set_defaults();
+
 private:
     friend class cereal::access;
 

--- a/include/hibf/hierarchical_interleaved_bloom_filter.hpp
+++ b/include/hibf/hierarchical_interleaved_bloom_filter.hpp
@@ -122,7 +122,7 @@ public:
      *   can be easily filtered in the down-stream analysis
      *
      * ## Validation
-     * \copybrief check_config_and_set_defaults
+     * \copybrief seqan::hibf::config::validate_and_set_defaults
      */
     hierarchical_interleaved_bloom_filter(config & configuration);
 

--- a/include/hibf/hierarchical_interleaved_bloom_filter.hpp
+++ b/include/hibf/hierarchical_interleaved_bloom_filter.hpp
@@ -106,9 +106,27 @@ public:
     operator=(hierarchical_interleaved_bloom_filter &&) = default; //!< Defaulted.
     ~hierarchical_interleaved_bloom_filter() = default;            //!< Defaulted.
 
+    /*!\brief Constructs the HIBF from the given configuration.
+     * \details
+     *
+     * ## Configuration
+     * Required options:
+     * * `input_fn`
+     * * `number_of_user_bins`
+     *
+     * Options recommended to adapt to your setup:
+     * * `threads` - Choose number of threads depending on your hardware settings to speed up construction
+     * * `maximum_false_positive_rate` - How many false positive answers can you tolerate? A low FPR (e.g. 0.001) is
+     *   needed if you can tolerate a high RAM peak when using the HIBF but post-processing steps are heavy and FPs
+     *   should be avoided. A high FPR (e.g. `0.3`) can be chosed if you want a very small HIBF and false positive
+     *   can be easily filtered in the down-stream analysis
+     *
+     * ## Validation
+     * \copybrief check_config_and_set_defaults
+     */
     hierarchical_interleaved_bloom_filter(config & configuration);
 
-    /*!\brief [Advanced] Constructs the HIBF from a layout file (stream) and a given input function
+    /*!\brief [Advanced] Constructs the HIBF from a layout file (stream) and a given input function.
      * \details
      * This constructor makes it possible to construct an hibf from a given layout file instead of calculating the
      * layout based on the input function. A seqan::hibf::config object is not needed as it is assumed to be stored in the

--- a/include/hibf/hierarchical_interleaved_bloom_filter.hpp
+++ b/include/hibf/hierarchical_interleaved_bloom_filter.hpp
@@ -106,7 +106,7 @@ public:
     operator=(hierarchical_interleaved_bloom_filter &&) = default; //!< Defaulted.
     ~hierarchical_interleaved_bloom_filter() = default;            //!< Defaulted.
 
-    hierarchical_interleaved_bloom_filter(config const & configuration);
+    hierarchical_interleaved_bloom_filter(config & configuration);
 
     /*!\brief [Advanced] Constructs the HIBF from a layout file (stream) and a given input function
      * \details

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -5,13 +5,17 @@
 // shipped with this file and also available at: https://github.com/seqan/hibf/blob/main/LICENSE.md
 // ---------------------------------------------------------------------------------------------------
 
-#include <cassert>     // for assert
+#include <cassert> // for assert
+#include <cmath>
+#include <iostream>
 #include <sstream>     // for basic_istream, basic_ostream, operator<<, basic_stringstream, stringstream
+#include <stdexcept>   // for invalid_argument
 #include <string>      // for char_traits, getline, operator<<, string
 #include <string_view> // for operator<<, operator==, basic_string_view
 
-#include <hibf/config.hpp>          // for config
-#include <hibf/layout/prefixes.hpp> // for meta_header, meta_hibf_config_end, meta_hibf_config_start
+#include <hibf/config.hpp>              // for config
+#include <hibf/layout/prefixes.hpp>     // for meta_header, meta_hibf_config_end, meta_hibf_config_start
+#include <hibf/next_multiple_of_64.hpp> // for next_multiple_of_64
 
 #include <cereal/archives/json.hpp> // for JSONInputArchive, JSONOutputArchive
 #include <cereal/cereal.hpp>        // for make_nvp, InputArchive, OutputArchive
@@ -57,6 +61,37 @@ void config::write_to(std::ostream & stream) const
         stream << prefix::meta_header << line << '\n';
     stream << prefix::meta_header << "}\n" // last closing bracket isn't written by loop above
            << prefix::meta_hibf_config_end << '\n';
+}
+
+void config::validate_and_set_defaults()
+{
+    if (disable_estimate_union)
+        disable_rearrangement = true;
+
+    if (number_of_user_bins == 0u)
+        throw std::invalid_argument{"[HIBF CONFIG ERROR] You did not set the required config::number_of_user_bins."};
+
+    if (tmax == 0) // no tmax was set by the user on the command line
+    {
+        // Set default as sqrt(#samples). Experiments showed that this is a reasonable default.
+        if (number_of_user_bins >= 1ULL << 32) // sqrt is bigger than uint16_t
+        {
+            throw std::invalid_argument{
+                "[HIBF CONFIG ERROR] Too many user bins to compute a default tmax. " // GCOVR_EXCL_LINE
+                "Please set a tmax manually."};                                      // GCOVR_EXCL_LINE
+        }
+        else
+        {
+            tmax = seqan::hibf::next_multiple_of_64(static_cast<uint16_t>(std::ceil(std::sqrt(number_of_user_bins))));
+        }
+    }
+    else if (tmax % 64 != 0)
+    {
+        tmax = seqan::hibf::next_multiple_of_64(tmax);
+        std::cerr << "[HIBF CONFIG WARNING]: Your requested number of technical bins was not a multiple of 64. "
+                  << "Due to the architecture of the HIBF, it will use up space equal to the next multiple of 64 "
+                  << "anyway, so we increased your number of technical bins to " << tmax << ".\n";
+    }
 }
 
 } // namespace seqan::hibf

--- a/src/hierarchical_interleaved_bloom_filter.cpp
+++ b/src/hierarchical_interleaved_bloom_filter.cpp
@@ -203,29 +203,25 @@ void build_index(hierarchical_interleaved_bloom_filter & hibf,
 
 /*!\brief Checks several variables of seqan::hibf::config and sets default values if necessary.
  *
- * The following checks are performed and might throw an exception if the configuration doesn't pass validation:
- * * If seqan::hibf::config::number_of_user_bins is `0` it is considered `not set` and an exception will be thrown
- *   because this paprameter is required.
- * * If seqan::hibf::config::tmax is `0` and seqan::hibf::config::number_of_user_bins is `>= 1ULL << 32` an exception
- *   will be thrown because a default tmax cannot be computed.
+ * The following checks are performed and will throw an exception if the checks fail:
+ * * seqan::hibf::config::number_of_user_bins must be greather than `0`.
+ * * If seqan::hibf::config::tmax is `0`, seqan::hibf::config::number_of_user_bins must be smaller than `1ULL << 32`.
  *
- * The configuration might be modified as follows before passed to the HIBF construction algorithm:
- * * If seqan::hibf::config::disable_estimate_union is set to true but seqan::hibf::config::disable_rearrangement
- *   is not, seqan::hibf::config::disable_rearrangement will be fordced to be true also. Without union estimations,
- *   no rearrangement can be done.
- * * If seqan::hibf::config::tmax is `0` it is considered `not set` and a default will be computed via
- *   `static_cast<uint16_t>(std::ceil(std::sqrt(cfg.number_of_user_bins)))`.
+ * The configuration might be modified before being passed to the HIBF construction algorithm:
+ * * If seqan::hibf::config::disable_estimate_union is `true`, seqan::hibf::config::disable_rearrangement will be set
+ *   to `true` . Without union estimation, no rearrangement can be done.
+ * * If seqan::hibf::config::tmax is `0`, the default value of `std::ceil(std::sqrt(cfg.number_of_user_bins))` will be
+ *   used.
  * * If seqan::hibf::config::tmax is **not** `0` but also not a multiple of 64, it is increased to the next multiple of
- *   64 to avoid uneccessary space consumption (e.g. value `60` will be increased to `64` or `1000` increased to `1024`).
+ *   64. E.g., the value `60` will be increased to `64`, and `1000` to `1024`.
  */
 void check_config_and_set_defaults(config & cfg)
 {
     if (cfg.disable_estimate_union)
         cfg.disable_rearrangement = true;
 
-    if (cfg.number_of_user_bins = 0)
-        throw std::invalid_argument{
-            "[HIBF CONFIG ERROR] You didn't set config::number_of_user_bins but it's required."};
+    if (cfg.number_of_user_bins == 0u)
+        throw std::invalid_argument{"[HIBF CONFIG ERROR] You did not set the required config::number_of_user_bins."};
 
     if (cfg.tmax == 0) // no tmax was set by the user on the command line
     {
@@ -233,8 +229,8 @@ void check_config_and_set_defaults(config & cfg)
         if (cfg.number_of_user_bins >= 1ULL << 32) // sqrt is bigger than uint16_t
         {
             throw std::invalid_argument{
-                "[HIBF CONFIG ERROR] Too many user-bins/samples to compute a default tmax. " // GCOVR_EXCL_LINE
-                "Please set a tmax manually."};                                              // GCOVR_EXCL_LINE
+                "[HIBF CONFIG ERROR] Too many user bins to compute a default tmax. " // GCOVR_EXCL_LINE
+                "Please set a tmax manually."};                                      // GCOVR_EXCL_LINE
         }
         else
         {

--- a/src/hierarchical_interleaved_bloom_filter.cpp
+++ b/src/hierarchical_interleaved_bloom_filter.cpp
@@ -201,6 +201,23 @@ void build_index(hierarchical_interleaved_bloom_filter & hibf,
     hibf.fill_ibf_timer = std::move(data.fill_ibf_timer);
 }
 
+/*!\brief Checks several variables of seqan::hibf::config and sets default values if necessary.
+ *
+ * The following checks are performed and might throw an exception if the configuration doesn't pass validation:
+ * * If seqan::hibf::config::number_of_user_bins is `0` it is considered `not set` and an exception will be thrown
+ *   because this paprameter is required.
+ * * If seqan::hibf::config::tmax is `0` and seqan::hibf::config::number_of_user_bins is `>= 1ULL << 32` an exception
+ *   will be thrown because a default tmax cannot be computed.
+ *
+ * The configuration might be modified as follows before passed to the HIBF construction algorithm:
+ * * If seqan::hibf::config::disable_estimate_union is set to true but seqan::hibf::config::disable_rearrangement
+ *   is not, seqan::hibf::config::disable_rearrangement will be fordced to be true also. Without union estimations,
+ *   no rearrangement can be done.
+ * * If seqan::hibf::config::tmax is `0` it is considered `not set` and a default will be computed via
+ *   `static_cast<uint16_t>(std::ceil(std::sqrt(cfg.number_of_user_bins)))`.
+ * * If seqan::hibf::config::tmax is **not** `0` but also not a multiple of 64, it is increased to the next multiple of
+ *   64 to avoid uneccessary space consumption (e.g. value `60` will be increased to `64` or `1000` increased to `1024`).
+ */
 void check_config_and_set_defaults(config & cfg)
 {
     if (cfg.disable_estimate_union)

--- a/src/layout/execute.cpp
+++ b/src/layout/execute.cpp
@@ -1,4 +1,4 @@
-#include <vector>    // for vector
+#include <vector> // for vector
 
 #include <hibf/config.hpp>                        // for config
 #include <hibf/layout/compute_fpr_correction.hpp> // for compute_fpr_correction
@@ -11,10 +11,9 @@ namespace seqan::hibf::layout
 
 size_t execute(seqan::hibf::config const & config, seqan::hibf::layout::data_store & data)
 {
-    data.fpr_correction =
-        compute_fpr_correction({.fpr = config.maximum_false_positive_rate, // prevent clang-format
-                                .hash_count = config.number_of_hash_functions,
-                                .t_max = config.tmax});
+    data.fpr_correction = compute_fpr_correction({.fpr = config.maximum_false_positive_rate, // prevent clang-format
+                                                  .hash_count = config.number_of_hash_functions,
+                                                  .t_max = config.tmax});
 
     return seqan::hibf::layout::hierarchical_binning{data, config}.execute();
 }

--- a/src/layout/execute.cpp
+++ b/src/layout/execute.cpp
@@ -1,8 +1,3 @@
-#include <cinttypes> // for uint16_t
-#include <cmath>     // for ceil, sqrt
-#include <cstddef>   // for size_t
-#include <iostream>  // for char_traits, operator<<, basic_ostream, cerr
-#include <stdexcept> // for invalid_argument
 #include <vector>    // for vector
 
 #include <hibf/config.hpp>                        // for config
@@ -10,42 +5,18 @@
 #include <hibf/layout/data_store.hpp>             // for data_store
 #include <hibf/layout/execute.hpp>                // for execute
 #include <hibf/layout/hierarchical_binning.hpp>   // for hierarchical_binning
-#include <hibf/next_multiple_of_64.hpp>           // for next_multiple_of_64
 
 namespace seqan::hibf::layout
 {
 
 size_t execute(seqan::hibf::config const & config, seqan::hibf::layout::data_store & data)
 {
-    seqan::hibf::config config_copy{config};
-
-    if (config_copy.disable_estimate_union)
-        config_copy.disable_rearrangement = true;
-
-    if (config_copy.tmax == 0) // no tmax was set by the user on the command line
-    {
-        // Set default as sqrt(#samples). Experiments showed that this is a reasonable default.
-        if (size_t number_samples = data.kmer_counts->size();
-            number_samples >= 1ULL << 32) // sqrt is bigger than uint16_t
-            throw std::invalid_argument{"Too many samples. Please set a tmax (see help via `-hh`)."}; // GCOVR_EXCL_LINE
-        else
-            config_copy.tmax =
-                seqan::hibf::next_multiple_of_64(static_cast<uint16_t>(std::ceil(std::sqrt(number_samples))));
-    }
-    else if (config_copy.tmax % 64 != 0)
-    {
-        config_copy.tmax = seqan::hibf::next_multiple_of_64(config_copy.tmax);
-        std::cerr << "[HIBF LAYOUT WARNING]: Your requested number of technical bins was not a multiple of 64. "
-                  << "Due to the architecture of the HIBF, it will use up space equal to the next multiple of 64 "
-                  << "anyway, so we increased your number of technical bins to " << config_copy.tmax << ".\n";
-    }
-
     data.fpr_correction =
-        compute_fpr_correction({.fpr = config_copy.maximum_false_positive_rate, // prevent clang-format
-                                .hash_count = config_copy.number_of_hash_functions,
-                                .t_max = config_copy.tmax});
+        compute_fpr_correction({.fpr = config.maximum_false_positive_rate, // prevent clang-format
+                                .hash_count = config.number_of_hash_functions,
+                                .t_max = config.tmax});
 
-    return seqan::hibf::layout::hierarchical_binning{data, config_copy}.execute();
+    return seqan::hibf::layout::hierarchical_binning{data, config}.execute();
 }
 
 } // namespace seqan::hibf::layout


### PR DESCRIPTION
I think it is very surprising if something in the configuration changes although you have passed a `const &`. So I moved the checking and default setting to the very top and removed the copy from `layout::execute`.

I added a little bit documentation.

Supersedes #34 