### PR TITLE
[TEST] Add benchmark for binning_bitvector

### DIFF
--- a/test/performance/ibf/CMakeLists.txt
+++ b/test/performance/ibf/CMakeLists.txt
@@ -1,1 +1,2 @@
+hibf_benchmark (binning_bitvector_benchmark.cpp)
 hibf_benchmark (interleaved_bloom_filter_benchmark.cpp)

--- a/test/performance/ibf/binning_bitvector_benchmark.cpp
+++ b/test/performance/ibf/binning_bitvector_benchmark.cpp
@@ -1,0 +1,146 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2023, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2023, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+#include <benchmark/benchmark.h>
+
+#include <hibf/interleaved_bloom_filter.hpp>
+
+using bitvector_t = seqan::hibf::interleaved_bloom_filter::binning_bitvector;
+
+static void arguments(benchmark::internal::Benchmark * b)
+{
+    // 1,024 bits (1 KiB)
+    b->Args({1024, 1024}); // No bit set
+    b->Args({1024, 0});    // First bit set
+#if 0
+    b->Args({1024, 64});   // First bit in second word set
+    b->Args({1024, 512});  // First bit set halfway
+
+    // // 8,192 bits (8 KiB)
+    b->Args({8192, 8192}); // No bit set
+    b->Args({8192, 0});    // First bit set
+    b->Args({8192, 64});   // First bit in second word set
+    b->Args({8192, 4096}); // First bit set halfway
+
+    // // 1,048,576 bits (1 MiB)
+    b->Args({1LL << 20, 1LL << 20}); // No bit set
+    b->Args({1LL << 20, 0});         // First bit set
+    b->Args({1LL << 20, 64});        // First bit in second word set
+    b->Args({1LL << 20, 1LL << 19}); // First bit set halfway
+#endif
+}
+
+class all_zero : public benchmark::Fixture
+{
+public:
+    void SetUp(benchmark::State const & state)
+    {
+        size_t const size_in_bits = state.range(0);
+        size_t const first_set_bit = state.range(1);
+
+        bitvector = bitvector_t(size_in_bits);
+        if (first_set_bit < size_in_bits)
+            bitvector[first_set_bit] = true;
+    }
+
+    void TearDown(benchmark::State const &)
+    {
+        bitvector.raw_data().clear();
+    }
+
+    bitvector_t const & get_bitvector() noexcept
+    {
+        return bitvector;
+    }
+
+private:
+    bitvector_t bitvector{};
+};
+
+BENCHMARK_DEFINE_F(all_zero, std_all_of)(benchmark::State & state)
+{
+    bitvector_t const & bitvector = get_bitvector();
+
+    for (auto _ : state)
+    {
+        bool result = std::all_of(bitvector.begin(),
+                                  bitvector.end(),
+                                  [](bool const value)
+                                  {
+                                      return !value;
+                                  });
+        benchmark::DoNotOptimize(result);
+    }
+}
+
+BENCHMARK_DEFINE_F(all_zero, std_ranges_all_of)(benchmark::State & state)
+{
+    bitvector_t const & bitvector = get_bitvector();
+
+    for (auto _ : state)
+    {
+        bool result = std::ranges::all_of(bitvector,
+                                          [](bool const value)
+                                          {
+                                              return !value;
+                                          });
+        benchmark::DoNotOptimize(result);
+    }
+}
+
+bool no_early_termination(bitvector_t const & bitvector) noexcept
+{
+    uint64_t const * const ptr = bitvector.raw_data().data();
+    size_t const number_of_words{bitvector.size() >> 6};
+    bool result{false};
+
+    for (size_t i{}; i < number_of_words; ++i)
+        result |= ptr[i];
+
+    return !result;
+}
+
+BENCHMARK_DEFINE_F(all_zero, ptr_no_early_termination)(benchmark::State & state)
+{
+    bitvector_t const & bitvector = get_bitvector();
+
+    for (auto _ : state)
+    {
+        bool result = no_early_termination(bitvector);
+        benchmark::DoNotOptimize(result);
+    }
+}
+
+bool with_early_termination(bitvector_t const & bitvector) noexcept
+{
+    uint64_t const * const ptr = bitvector.raw_data().data();
+    size_t const number_of_words{bitvector.size() >> 6};
+    bool result{false};
+
+    for (size_t i{}; !result && i < number_of_words; ++i)
+        result |= ptr[i];
+
+    return !result;
+}
+
+BENCHMARK_DEFINE_F(all_zero, ptr_with_early_termination)(benchmark::State & state)
+{
+    bitvector_t const & bitvector = get_bitvector();
+
+    for (auto _ : state)
+    {
+        bool result = with_early_termination(bitvector);
+        benchmark::DoNotOptimize(result);
+    }
+}
+
+BENCHMARK_REGISTER_F(all_zero, std_all_of)->Apply(arguments);
+BENCHMARK_REGISTER_F(all_zero, std_ranges_all_of)->Apply(arguments);
+BENCHMARK_REGISTER_F(all_zero, ptr_no_early_termination)->Apply(arguments);
+BENCHMARK_REGISTER_F(all_zero, ptr_with_early_termination)->Apply(arguments);
+
+BENCHMARK_MAIN();


### PR DESCRIPTION
```
----------------------------------------------------------------------------------------------
Benchmark                                                    Time             CPU   Iterations
----------------------------------------------------------------------------------------------
all_zero/std_all_of/1024/1024                             1598 ns         1598 ns       459151
all_zero/std_all_of/1024/0                                12.0 ns         12.0 ns     54763741
all_zero/std_all_of/1024/64                                106 ns          106 ns      6569957
all_zero/std_all_of/1024/512                               810 ns          810 ns       899914
all_zero/std_all_of/8192/8192                            13116 ns        13116 ns        55135
all_zero/std_all_of/8192/0                                12.9 ns         12.9 ns     51673177
all_zero/std_all_of/8192/64                                112 ns          112 ns      6576833
all_zero/std_all_of/8192/4096                             6231 ns         6231 ns       106150
all_zero/std_all_of/1048576/1048576                    1603100 ns      1603075 ns          439
all_zero/std_all_of/1048576/0                             12.2 ns         12.2 ns     57039441
all_zero/std_all_of/1048576/64                             109 ns          109 ns      6488018
all_zero/std_all_of/1048576/524288                      797251 ns       797240 ns          889

all_zero/std_ranges_all_of/1024/1024                      1646 ns         1646 ns       428828
all_zero/std_ranges_all_of/1024/0                         7.34 ns         7.34 ns     98261612
all_zero/std_ranges_all_of/1024/64                         111 ns          111 ns      5625459
all_zero/std_ranges_all_of/1024/512                        830 ns          830 ns       848525
all_zero/std_ranges_all_of/8192/8192                     12938 ns        12937 ns        54686
all_zero/std_ranges_all_of/8192/0                         7.24 ns         7.24 ns     96785612
all_zero/std_ranges_all_of/8192/64                         107 ns          107 ns      6312670
all_zero/std_ranges_all_of/8192/4096                      6471 ns         6471 ns        94017
all_zero/std_ranges_all_of/1048576/1048576             1653648 ns      1653652 ns          426
all_zero/std_ranges_all_of/1048576/0                      7.44 ns         7.44 ns     97924285
all_zero/std_ranges_all_of/1048576/64                      107 ns          107 ns      6491110
all_zero/std_ranges_all_of/1048576/524288               820002 ns       819946 ns          834

all_zero/ptr_no_early_termination/1024/1024               13.9 ns         13.9 ns     50748909
all_zero/ptr_no_early_termination/1024/0                  13.8 ns         13.8 ns     50967435
all_zero/ptr_no_early_termination/1024/64                 13.9 ns         13.9 ns     48664338
all_zero/ptr_no_early_termination/1024/512                13.7 ns         13.7 ns     48021151
all_zero/ptr_no_early_termination/8192/8192                116 ns          116 ns      5971769
all_zero/ptr_no_early_termination/8192/0                   118 ns          118 ns      5906385
all_zero/ptr_no_early_termination/8192/64                  117 ns          117 ns      5866076
all_zero/ptr_no_early_termination/8192/4096                117 ns          117 ns      6074543
all_zero/ptr_no_early_termination/1048576/1048576        14451 ns        14451 ns        48514
all_zero/ptr_no_early_termination/1048576/0              14410 ns        14409 ns        48571
all_zero/ptr_no_early_termination/1048576/64             14467 ns        14467 ns        48788
all_zero/ptr_no_early_termination/1048576/524288         14626 ns        14626 ns        46859

all_zero/ptr_with_early_termination/1024/1024             13.6 ns         13.6 ns     51746481
all_zero/ptr_with_early_termination/1024/0                1.61 ns         1.61 ns    341722123
all_zero/ptr_with_early_termination/1024/64               2.33 ns         2.33 ns    300896025
all_zero/ptr_with_early_termination/1024/512              7.96 ns         7.96 ns     88797442
all_zero/ptr_with_early_termination/8192/8192              105 ns          105 ns      6691451
all_zero/ptr_with_early_termination/8192/0                1.63 ns         1.63 ns    424880002
all_zero/ptr_with_early_termination/8192/64               2.34 ns         2.34 ns    302203756
all_zero/ptr_with_early_termination/8192/4096             53.3 ns         53.3 ns     13259258
all_zero/ptr_with_early_termination/1048576/1048576      12916 ns        12916 ns        54507
all_zero/ptr_with_early_termination/1048576/0             1.63 ns         1.63 ns    433623675
all_zero/ptr_with_early_termination/1048576/64            2.50 ns         2.50 ns    281652285
all_zero/ptr_with_early_termination/1048576/524288        6547 ns         6547 ns       102566
```