### PR TITLE
[FIX] config validation

### DIFF
--- a/include/hibf/config.hpp
+++ b/include/hibf/config.hpp
@@ -31,7 +31,7 @@ struct config
      * \{
      */
     //!\brief A lambda how to hash your input. TODO: Detailed docu needed!
-    std::function<void(size_t const, insert_iterator &&)> input_fn;
+    std::function<void(size_t const, insert_iterator &&)> input_fn{};
 
     //!\brief Number of user bins
     size_t number_of_user_bins{};
@@ -53,7 +53,7 @@ struct config
     uint8_t sketch_bits{12};
 
     //!\brief The maximum number of technical bins on each IBF in the HIBF.
-    uint16_t tmax{64};
+    uint16_t tmax{};
 
     /*\brief A scaling factor to influence the amount of merged bins produced by the algorithm.
      *

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -74,7 +74,7 @@ void config::validate_and_set_defaults()
     if (tmax == 0) // no tmax was set by the user on the command line
     {
         // Set default as sqrt(#samples). Experiments showed that this is a reasonable default.
-        if (number_of_user_bins >= 1ULL << 32) // sqrt is bigger than uint16_t
+        if (number_of_user_bins > 4'286'582'784ULL) // https://godbolt.org/z/oPh18s7cM
         {
             throw std::invalid_argument{
                 "[HIBF CONFIG ERROR] Too many user bins to compute a default tmax. " // GCOVR_EXCL_LINE
@@ -84,6 +84,10 @@ void config::validate_and_set_defaults()
         {
             tmax = seqan::hibf::next_multiple_of_64(static_cast<uint16_t>(std::ceil(std::sqrt(number_of_user_bins))));
         }
+    }
+    else if (tmax > 65472u) // next_multiple_of_64 would return 65536, does not fit in uint16_t
+    {
+        throw std::invalid_argument{"[HIBF CONFIG ERROR] The maximum possible tmax is 65472."};
     }
     else if (tmax % 64 != 0)
     {

--- a/test/unit/hibf/config_test.cpp
+++ b/test/unit/hibf/config_test.cpp
@@ -119,3 +119,117 @@ TEST(config_test, read_from_with_more_meta)
     EXPECT_EQ(configuration.disable_estimate_union, true);
     EXPECT_EQ(configuration.disable_rearrangement, false);
 }
+
+TEST(config_test, validate_and_set_defaults)
+{
+    // Set disable_rearrangement if disable_estimate_union is set
+    {
+        seqan::hibf::config configuration{.number_of_user_bins = 1u, .disable_estimate_union = true};
+        EXPECT_TRUE(configuration.disable_estimate_union);
+        EXPECT_FALSE(configuration.disable_rearrangement);
+
+        testing::internal::CaptureStderr();
+        configuration.validate_and_set_defaults();
+        EXPECT_TRUE(configuration.disable_estimate_union);
+        EXPECT_TRUE(configuration.disable_rearrangement);
+        EXPECT_EQ((testing::internal::GetCapturedStderr()), "");
+    }
+
+    // number_of_user_bins cannot be 0
+    {
+        seqan::hibf::config configuration{};
+
+        try
+        {
+            configuration.validate_and_set_defaults();
+            FAIL();
+        }
+        catch (std::invalid_argument const & exception)
+        {
+            EXPECT_STREQ("[HIBF CONFIG ERROR] You did not set the required config::number_of_user_bins.",
+                         exception.what());
+        }
+        catch (...)
+        {
+            FAIL();
+        }
+    }
+
+    // Set default tmax
+    {
+        seqan::hibf::config configuration{.number_of_user_bins = 4'286'582'784ULL};
+        EXPECT_EQ(configuration.tmax, 0u);
+
+        testing::internal::CaptureStderr();
+        configuration.validate_and_set_defaults();
+        EXPECT_EQ(configuration.tmax, 65472u);
+        EXPECT_EQ((testing::internal::GetCapturedStderr()), "");
+    }
+
+    // Cannot set default tmax
+    {
+        seqan::hibf::config configuration{.number_of_user_bins = 4'286'582'785ULL};
+        EXPECT_EQ(configuration.tmax, 0u);
+
+        try
+        {
+            configuration.validate_and_set_defaults();
+            FAIL();
+        }
+        catch (std::invalid_argument const & exception)
+        {
+            EXPECT_STREQ(
+                "[HIBF CONFIG ERROR] Too many user bins to compute a default tmax. Please set a tmax manually.",
+                exception.what());
+        }
+        catch (...)
+        {
+            FAIL();
+        }
+    }
+
+    // Given tmax OK
+    {
+        seqan::hibf::config configuration{.number_of_user_bins = 1u, .tmax = 65472u};
+
+        testing::internal::CaptureStderr();
+        configuration.validate_and_set_defaults();
+
+        EXPECT_EQ(configuration.number_of_user_bins, 1u);
+        EXPECT_EQ(configuration.tmax, 65472u);
+        EXPECT_EQ((testing::internal::GetCapturedStderr()), "");
+    }
+
+    // Given tmax too big
+    {
+        seqan::hibf::config configuration{.number_of_user_bins = 1u, .tmax = 65473u};
+
+        try
+        {
+            configuration.validate_and_set_defaults();
+            FAIL();
+        }
+        catch (std::invalid_argument const & exception)
+        {
+            EXPECT_STREQ("[HIBF CONFIG ERROR] The maximum possible tmax is 65472.", exception.what());
+        }
+        catch (...)
+        {
+            FAIL();
+        }
+    }
+
+    // Given tmax is not a multiple of 64
+    {
+        seqan::hibf::config configuration{.number_of_user_bins = 32u, .tmax = 32u};
+        EXPECT_EQ(configuration.tmax, 32u);
+
+        testing::internal::CaptureStderr();
+        configuration.validate_and_set_defaults();
+        EXPECT_EQ(configuration.tmax, 64u);
+        EXPECT_EQ((testing::internal::GetCapturedStderr()),
+                  "[HIBF CONFIG WARNING]: Your requested number of technical bins was not a multiple of 64. Due to the "
+                  "architecture of the HIBF, it will use up space equal to the next multiple of 64 anyway, so we "
+                  "increased your number of technical bins to 64.\n");
+    }
+}


### PR DESCRIPTION
* `tmax` shouldn't be initialised to a value other than 0, otherwise we will never set a default
* the max number of bins for setting a default tmax was wrong
* tmax cannot be bigger than `65472`, because the next multiple of 64 would be `65536`

For discussion:
* Make tmax a `size_t`?
* Initialising `input_fn` in the config is needed such that `input_fn` doesn't need to be provided when using designated intialisers (`input_fn` would be uninitialised otherwise, default ctor is not affected). Would be a way to make `input_fn` mandatory, but it doesn't really seem in the spirit of designated initialisers, and it would also hinder use cases such as first using desginated initialisers for construction, and setting `input_fn` afterwards (workaround would probably be `.input_fn = {}`).